### PR TITLE
Use yaml.safeLoad instead of load

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,6 @@ module.exports = robot => {
     const path = '.github/state.yml';
     const res = await context.github.repos.getContent(context.repo({path}));
 
-    return yaml.load(Buffer.from(res.data.content, 'base64').toString()) || {};
+    return yaml.safeLoad(Buffer.from(res.data.content, 'base64').toString()) || {};
   }
 };


### PR DESCRIPTION
Fixes issue where untrusted yaml file could contain JavaScript: https://github.com/nodeca/js-yaml#safeload-string---options-